### PR TITLE
Instance Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fixed creation and attachment of additional EBS volumes ([#1](https://github.com/WildBeavers/terraform-aws-ec2-instance/issues/1))
 - Add replacement of `${hostname}` in `user_data` with the hostname of the EC2 instance ([#2](https://github.com/WildBeavers/terraform-aws-ec2-instance/issues/2))
 - Change `ignore_changes` of lifecycle for EC2 instance: use hard coded values `ami` and `user_data` ([#3](https://github.com/WildBeavers/terraform-aws-ec2-instance/issues/3))
-
+- Support new Terraform 0.12 feature: EC2 instance as output  ([#4](https://github.com/WildBeavers/terraform-aws-ec2-instance/issues/4))
 
 <a name="v2.6.0"></a>
 ## [v2.6.0] - 2019-07-21

--- a/docs/user/outputs.md
+++ b/docs/user/outputs.md
@@ -2,20 +2,21 @@
 
 | Name | Description |
 |------|-------------|
-| availability_zone | List of availability zones of instances |
-| credit_specification | List of credit specification of instances |
-| id | List of IDs of instances |
-| key_name | List of key names of instances |
-| password_data | List of Base-64 encoded encrypted password data for the instance |
-| placement_group | List of placement groups of instances |
-| primary_network_interface_id | List of IDs of the primary network interface of instances |
-| private_dns | List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC |
-| private_ip | List of private IP addresses assigned to the instances |
-| public_dns | List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC |
-| public_ip | List of public IP addresses assigned to the instances, if applicable |
-| security_groups | List of associated security groups of instances |
-| subnet_id | List of IDs of VPC subnets of instances |
-| tags | List of tags of instances |
-| volume_tags | List of tags of volumes of instances |
-| vpc_security_group_ids | List of associated security groups of instances, if running in non-default VPC |
+| availability_zone | (DEPRECATED)     List of availability zones of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.availability_zone |
+| credit_specification | (DEPRECATED)     List of credit specification of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       flatten(module.module_name.instances.*.credit_specification) |
+| id | (DEPRECATED)     List of IDs of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.id |
+| instances | List of EC2 Instance Objects |
+| key_name | (DEPRECATED)     List of key names of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.key_name |
+| password_data | (DEPRECATED)     List of Base-64 encoded encrypted password data for the instance<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.password_data |
+| placement_group | (DEPRECATED)     List of placement groups of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       compact(module.module_name.instances.*.placement_group) |
+| primary_network_interface_id | (DEPRECATED)     List of IDs of the primary network interface of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.primary_network_interface_id |
+| private_dns | (DEPRECATED)     List of private DNS names assigned to the instances. Can only be used       inside the Amazon EC2, and only available if you've enabled DNS       hostnames for your VPC<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.private_dns |
+| private_ip | (DEPRECATED)     List of private IP addresses assigned to the instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.private_ip |
+| public_dns | (DEPRECATED)     List of public DNS names assigned to the instances. For EC2-VPC, this is       only available if you've enabled DNS hostnames for your VPC<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       compact(module.module_name.instances.*.public_dns) |
+| public_ip | (DEPRECATED)     List of public IP addresses assigned to the instances, if applicable<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       compact(module.module_name.instances.*.public_ip) |
+| security_groups | (DEPRECATED)     List of associated security groups of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.security_groups |
+| subnet_id | (DEPRECATED)     List of IDs of VPC subnets of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.subnet_id |
+| tags | (DEPRECATED)     List of tags of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.tags |
+| volume_tags | (DEPRECATED)     List of tags of volumes of instances<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       module.module_name.instances.*.volume_tags |
+| vpc_security_group_ids | (DEPRECATED)     List of associated security groups of instances,       if running  in non-default VPC<br><br>    Deprecation Notice:       To continue using this value, like in earlier versions, please use the       following expression:       flatten(module.module_name.instances.*.vpc_security_group_ids) |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -69,7 +69,7 @@ output "credit_specification" {
     Deprecation Notice:
       To continue using this value, like in earlier versions, please use the
       following expression:
-      ${flatten(module.module_name.instances.*.credit_specification)}
+      flatten(module.module_name.instances.*.credit_specification)
   EOF
 
   value = "${local.this_credit_specification}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,6 +31,14 @@ locals {
   this_vpc_security_group_ids       = "${coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])}"
 }
 
+output "instances" {
+  description = <<EOF
+    List of EC2 Instance Objects
+  EOF
+
+  value = "${aws_instance.this}"
+}
+
 /*  -------------------------------------------------------------------------
     Deprecated Outputs
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,12 @@
 
     ######################################################################### */
 
+/*  -------------------------------------------------------------------------
+    Deprecated Locals
+
+    The following Locals are deprecated. They all can be replaced by
+    referencing the `instances` Output.
+    ------------------------------------------------------------------------- */
 locals {
   this_availability_zone            = "${compact(coalescelist(aws_instance.this.*.availability_zone, [""]))}"
   this_credit_specification         = "${flatten(aws_instance.this.*.credit_specification)}"
@@ -25,82 +31,238 @@ locals {
   this_vpc_security_group_ids       = "${coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])}"
 }
 
+/*  -------------------------------------------------------------------------
+    Deprecated Outputs
+
+    The following Outputs are deprecated. They all can be replaced by
+    referencing the `instances` Output. Examples for a drop-in replacement
+    have been added to each deprecated Output.
+    ------------------------------------------------------------------------- */
+
 output "availability_zone" {
-  description = "List of availability zones of instances"
-  value       = "${local.this_availability_zone}"
+  description = <<EOF
+    (DEPRECATED)
+    List of availability zones of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.availability_zone
+  EOF
+
+  value = "${local.this_availability_zone}"
 }
 
 output "credit_specification" {
-  description = "List of credit specification of instances"
-  value       = "${local.this_credit_specification}"
+  description = <<EOF
+    (DEPRECATED)
+    List of credit specification of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      ${flatten(module.module_name.instances.*.credit_specification)}
+  EOF
+
+  value = "${local.this_credit_specification}"
 }
 
 output "id" {
-  description = "List of IDs of instances"
-  value       = "${local.this_id}"
+  description = <<EOF
+    (DEPRECATED)
+    List of IDs of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.id
+  EOF
+
+  value = "${local.this_id}"
 }
 
 output "key_name" {
-  description = "List of key names of instances"
-  value       = "${local.this_key_name}"
+  description = <<EOF
+    (DEPRECATED)
+    List of key names of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.key_name
+  EOF
+
+  value = "${local.this_key_name}"
 }
 
 output "password_data" {
-  description = "List of Base-64 encoded encrypted password data for the instance"
-  value       = "${local.this_password_data}"
+  description = <<EOF
+    (DEPRECATED)
+    List of Base-64 encoded encrypted password data for the instance
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.password_data
+  EOF
+
+  value = "${local.this_password_data}"
 }
 
 output "placement_group" {
-  description = "List of placement groups of instances"
-  value       = "${local.this_placement_group}"
+  description = <<EOF
+    (DEPRECATED)
+    List of placement groups of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      compact(module.module_name.instances.*.placement_group)
+  EOF
+
+  value = "${local.this_placement_group}"
 }
 
 output "primary_network_interface_id" {
-  description = "List of IDs of the primary network interface of instances"
-  value       = "${local.this_primary_network_interface_id}"
+  description = <<EOF
+    (DEPRECATED)
+    List of IDs of the primary network interface of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.primary_network_interface_id
+  EOF
+
+  value = "${local.this_primary_network_interface_id}"
 }
 
 output "private_dns" {
-  description = "List of private DNS names assigned to the instances. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC"
-  value       = "${local.this_private_dns}"
+  description = <<EOF
+    (DEPRECATED)
+    List of private DNS names assigned to the instances. Can only be used
+      inside the Amazon EC2, and only available if you've enabled DNS
+      hostnames for your VPC
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.private_dns
+  EOF
+
+  value = "${local.this_private_dns}"
 }
 
 output "private_ip" {
-  description = "List of private IP addresses assigned to the instances"
-  value       = "${local.this_private_ip}"
+  description = <<EOF
+    (DEPRECATED)
+    List of private IP addresses assigned to the instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.private_ip
+  EOF
+
+  value = "${local.this_private_ip}"
 }
 
 output "public_dns" {
-  description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       = "${local.this_public_dns}"
+  description = <<EOF
+    (DEPRECATED)
+    List of public DNS names assigned to the instances. For EC2-VPC, this is
+      only available if you've enabled DNS hostnames for your VPC
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      compact(module.module_name.instances.*.public_dns)
+  EOF
+
+  value = "${local.this_public_dns}"
 }
 
 output "public_ip" {
-  description = "List of public IP addresses assigned to the instances, if applicable"
-  value       = "${local.this_public_ip}"
+  description = <<EOF
+    (DEPRECATED)
+    List of public IP addresses assigned to the instances, if applicable
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      compact(module.module_name.instances.*.public_ip)
+  EOF
+
+  value = "${local.this_public_ip}"
 }
 
 output "security_groups" {
-  description = "List of associated security groups of instances"
-  value       = "${local.this_security_groups}"
+  description = <<EOF
+    (DEPRECATED)
+    List of associated security groups of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.security_groups
+  EOF
+
+  value = "${local.this_security_groups}"
 }
 
 output "subnet_id" {
-  description = "List of IDs of VPC subnets of instances"
-  value       = "${local.this_subnet_id}"
+  description = <<EOF
+    (DEPRECATED)
+    List of IDs of VPC subnets of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.subnet_id
+  EOF
+
+  value = "${local.this_subnet_id}"
 }
 
 output "tags" {
-  description = "List of tags of instances"
-  value       = "${local.this_tags}"
+  description = <<EOF
+    (DEPRECATED)
+    List of tags of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.tags
+  EOF
+
+  value = "${local.this_tags}"
 }
 
 output "volume_tags" {
-  description = "List of tags of volumes of instances"
-  value       = "${local.this_volume_tags}"
+  description = <<EOF
+    (DEPRECATED)
+    List of tags of volumes of instances
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      module.module_name.instances.*.volume_tags
+  EOF
+
+  value = "${local.this_volume_tags}"
 }
 
 output "vpc_security_group_ids" {
-  description = "List of associated security groups of instances, if running in non-default VPC"
-  value       = "${local.this_vpc_security_group_ids}"
+  description = <<EOF
+    (DEPRECATED)
+    List of associated security groups of instances,
+      if running  in non-default VPC
+
+    Deprecation Notice:
+      To continue using this value, like in earlier versions, please use the
+      following expression:
+      flatten(module.module_name.instances.*.vpc_security_group_ids)
+  EOF
+
+  value = "${local.this_vpc_security_group_ids}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,27 +7,22 @@
     ######################################################################### */
 
 locals {
-  this_id                           = "${compact(coalescelist(aws_instance.this.*.id, [""]))}"
   this_availability_zone            = "${compact(coalescelist(aws_instance.this.*.availability_zone, [""]))}"
+  this_credit_specification         = "${flatten(aws_instance.this.*.credit_specification)}"
+  this_id                           = "${compact(coalescelist(aws_instance.this.*.id, [""]))}"
   this_key_name                     = "${compact(coalescelist(aws_instance.this.*.key_name, [""]))}"
-  this_public_dns                   = "${compact(coalescelist(aws_instance.this.*.public_dns, [""]))}"
-  this_public_ip                    = "${compact(coalescelist(aws_instance.this.*.public_ip, [""]))}"
+  this_password_data                = "${coalescelist(aws_instance.this.*.password_data, [""])}"
+  this_placement_group              = "${compact(coalescelist(aws_instance.this.*.placement_group, [""]))}"
   this_primary_network_interface_id = "${compact(coalescelist(aws_instance.this.*.primary_network_interface_id, [""]))}"
   this_private_dns                  = "${compact(coalescelist(aws_instance.this.*.private_dns, [""]))}"
   this_private_ip                   = "${compact(coalescelist(aws_instance.this.*.private_ip, [""]))}"
-  this_placement_group              = "${compact(coalescelist(aws_instance.this.*.placement_group, [""]))}"
+  this_public_dns                   = "${compact(coalescelist(aws_instance.this.*.public_dns, [""]))}"
+  this_public_ip                    = "${compact(coalescelist(aws_instance.this.*.public_ip, [""]))}"
   this_security_groups              = "${coalescelist(aws_instance.this.*.security_groups, [""])}"
-  this_vpc_security_group_ids       = "${coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])}"
   this_subnet_id                    = "${compact(coalescelist(aws_instance.this.*.subnet_id, [""]))}"
-  this_credit_specification         = "${flatten(aws_instance.this.*.credit_specification)}"
   this_tags                         = "${coalescelist(aws_instance.this.*.tags, [""])}"
   this_volume_tags                  = "${coalescelist(aws_instance.this.*.volume_tags, [""])}"
-  this_password_data                = "${coalescelist(aws_instance.this.*.password_data, [""])}"
-}
-
-output "id" {
-  description = "List of IDs of instances"
-  value       = "${local.this_id}"
+  this_vpc_security_group_ids       = "${coalescelist(flatten(aws_instance.this.*.vpc_security_group_ids), [""])}"
 }
 
 output "availability_zone" {
@@ -35,9 +30,14 @@ output "availability_zone" {
   value       = "${local.this_availability_zone}"
 }
 
-output "placement_group" {
-  description = "List of placement groups of instances"
-  value       = "${local.this_placement_group}"
+output "credit_specification" {
+  description = "List of credit specification of instances"
+  value       = "${local.this_credit_specification}"
+}
+
+output "id" {
+  description = "List of IDs of instances"
+  value       = "${local.this_id}"
 }
 
 output "key_name" {
@@ -45,14 +45,14 @@ output "key_name" {
   value       = "${local.this_key_name}"
 }
 
-output "public_dns" {
-  description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
-  value       = "${local.this_public_dns}"
+output "password_data" {
+  description = "List of Base-64 encoded encrypted password data for the instance"
+  value       = "${local.this_password_data}"
 }
 
-output "public_ip" {
-  description = "List of public IP addresses assigned to the instances, if applicable"
-  value       = "${local.this_public_ip}"
+output "placement_group" {
+  description = "List of placement groups of instances"
+  value       = "${local.this_placement_group}"
 }
 
 output "primary_network_interface_id" {
@@ -70,9 +70,14 @@ output "private_ip" {
   value       = "${local.this_private_ip}"
 }
 
-output "password_data" {
-  description = "List of Base-64 encoded encrypted password data for the instance"
-  value       = "${local.this_password_data}"
+output "public_dns" {
+  description = "List of public DNS names assigned to the instances. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC"
+  value       = "${local.this_public_dns}"
+}
+
+output "public_ip" {
+  description = "List of public IP addresses assigned to the instances, if applicable"
+  value       = "${local.this_public_ip}"
 }
 
 output "security_groups" {
@@ -80,19 +85,9 @@ output "security_groups" {
   value       = "${local.this_security_groups}"
 }
 
-output "vpc_security_group_ids" {
-  description = "List of associated security groups of instances, if running in non-default VPC"
-  value       = "${local.this_vpc_security_group_ids}"
-}
-
 output "subnet_id" {
   description = "List of IDs of VPC subnets of instances"
   value       = "${local.this_subnet_id}"
-}
-
-output "credit_specification" {
-  description = "List of credit specification of instances"
-  value       = "${local.this_credit_specification}"
 }
 
 output "tags" {
@@ -103,4 +98,9 @@ output "tags" {
 output "volume_tags" {
   description = "List of tags of volumes of instances"
   value       = "${local.this_volume_tags}"
+}
+
+output "vpc_security_group_ids" {
+  description = "List of associated security groups of instances, if running in non-default VPC"
+  value       = "${local.this_vpc_security_group_ids}"
 }


### PR DESCRIPTION
This will add a new Output that returns the whole aws_instance object. All other Outputs will be marked as deprecated as they all can be replaced by using the new output.